### PR TITLE
fix windows path error

### DIFF
--- a/mGPT/config.py
+++ b/mGPT/config.py
@@ -14,7 +14,7 @@ def get_module_config(cfg, filepath="./configs"):
     yamls = glob.glob(pjoin(filepath, '*', '*.yaml'))
     yamls = [y.replace(filepath, '') for y in yamls]
     for yaml in yamls:
-        nodes = yaml.replace('.yaml', '').replace('/', '.')
+        nodes = yaml.replace('.yaml', '').replace(os.sep, '.')
         nodes = nodes[1:] if nodes[0] == '.' else nodes
         OmegaConf.update(cfg, nodes, OmegaConf.load('./configs' + yaml))
 


### PR DESCRIPTION
On windows 
`yamls = glob.glob(os.path.join(filepath, '*', '*.yaml'))` will produce double backslash.
So `nodes = yaml.replace('.yaml', '').replace('/', '.')` will not work as expected.
Using os.sep will fix the issue: https://github.com/OpenMotionLab/MotionGPT/issues/65